### PR TITLE
Initialize Next.js MVP frontend boilerplate

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Component MVP Frontend
+
+This project is a Next.js (TypeScript) frontend for experimenting with user-authored React components. It features:
+
+- Monaco editor for entering component code.
+- Sandpack-powered preview in an isolated iframe with Tailwind CSS provided via CDN.
+- Dynamic property form driven by a simple schema.
+- Basic client-side validation for component size and external imports.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Scripts
+
+- `npm run dev` – start Next.js dev server
+- `npm run build` – production build
+- `npm test` – placeholder test script
+
+## TODO
+
+- Integrate backend API for persisting components
+- Improved prop schema extraction
+- Robust security hardening

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <title>Component MVP</title>
+      </head>
+      <body className="min-h-screen bg-gray-50 text-gray-900">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Editor from '../components/Editor';
+import Preview from '../components/Preview';
+import PropForm from '../components/PropForm';
+import { validateComponent } from '../lib/validation';
+
+const defaultCode = `export default function Example({ message = "Hello" }) {
+  return <div className="p-4 text-xl">{message}</div>;
+}`;
+
+type PropValues = Record<string, unknown>;
+
+export default function Page() {
+  const [code, setCode] = useState(defaultCode);
+  const [props, setProps] = useState<PropValues>({ message: 'Hello' });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const result = validateComponent(code);
+    setError(result.valid ? null : result.error || 'Invalid component');
+  }, [code]);
+
+  return (
+    <main className="p-4 grid gap-4 md:grid-cols-2">
+      <section>
+        <Editor value={code} onChange={setCode} />
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      </section>
+      <section className="space-y-4">
+        <PropForm
+          schema={{ message: 'string' }}
+          values={props}
+          onChange={(key, value) => setProps((p) => ({ ...p, [key]: value }))}
+        />
+        <div className="h-80 border rounded overflow-hidden">
+          <Preview code={code} props={props} />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { editor } from 'monaco-editor';
+import { useCallback } from 'react';
+
+const MonacoEditor = dynamic(async () => (await import('@monaco-editor/react')).default, {
+  ssr: false,
+});
+
+interface EditorProps {
+  value: string;
+  onChange: (code: string) => void;
+}
+
+export default function Editor({ value, onChange }: EditorProps) {
+  const handleChange = useCallback((val?: string) => {
+    onChange(val ?? '');
+  }, [onChange]);
+
+  return (
+    <MonacoEditor
+      height="400px"
+      defaultLanguage="typescript"
+      value={value}
+      onChange={handleChange}
+      options={{ minimap: { enabled: false }, fontSize: 14 }}
+    />
+  );
+}

--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { SandpackProvider, SandpackPreview } from '@sandpack/react';
+import { useMemo } from 'react';
+
+interface PreviewProps {
+  code: string;
+  props: Record<string, unknown>;
+}
+
+export default function Preview({ code, props }: PreviewProps) {
+  const files = useMemo(
+    () => ({
+      '/App.tsx': code,
+      '/index.tsx': `import React from "react";\nimport ReactDOM from "react-dom/client";\nimport App from './App';\n\nconst root = document.getElementById('root');\nReactDOM.createRoot(root!).render(<App {...${JSON.stringify(
+        props
+      )}} />);\n`,
+    }),
+    [code, props]
+  );
+
+  return (
+    <SandpackProvider
+      template="react-ts"
+      files={files}
+      options={{
+        externalResources: ['https://cdn.tailwindcss.com'],
+        classes: { 'sp-preview-container': '!h-full' },
+      }}
+    >
+      <SandpackPreview style={{ height: '100%' }} />
+    </SandpackProvider>
+  );
+}

--- a/components/PropForm.tsx
+++ b/components/PropForm.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+type PropType = 'string' | 'number' | 'boolean';
+type PropSchema = Record<string, PropType>;
+
+interface PropFormProps {
+  schema: PropSchema;
+  values: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}
+
+export default function PropForm({ schema, values, onChange }: PropFormProps) {
+  return (
+    <form className="space-y-2">
+      {Object.entries(schema).map(([key, type]) => (
+        <label key={key} className="block text-sm">
+          <span className="mb-1 block font-medium capitalize">{key}</span>
+          {type === 'boolean' ? (
+            <input
+              type="checkbox"
+              checked={Boolean(values[key])}
+              onChange={(e) => onChange(key, e.target.checked)}
+            />
+          ) : (
+            <input
+              type={type === 'number' ? 'number' : 'text'}
+              className="border rounded px-2 py-1 w-full"
+              value={String(values[key] ?? '')}
+              onChange={(e) =>
+                onChange(
+                  key,
+                  type === 'number' ? Number(e.target.value) : e.target.value
+                )
+              }
+            />
+          )}
+        </label>
+      ))}
+    </form>
+  );
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,9 @@
+export function validateComponent(code: string): { valid: boolean; error?: string } {
+  if (/import\s+.*from\s+['"].+['"]/m.test(code)) {
+    return { valid: false, error: 'External imports are not allowed' };
+  }
+  if (code.length > 200_000) {
+    return { valid: false, error: 'Component code must be <= 200KB' };
+  }
+  return { valid: true };
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "component-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests configured\""
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@monaco-editor/react": "4.5.0",
+    "@sandpack/react": "2.8.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.33",
+    "@types/node": "20.11.25",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "tailwindcss": "3.4.1",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js + TypeScript project with Tailwind config and linting
- add Monaco editor, Sandpack preview, and prop form components for client-side component editing
- implement basic validation to block external imports and overly large components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9df4883f483289d47debec5d316d2